### PR TITLE
fix: field builder context type inference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maroonedog/luq",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2-alpha",
   "description": "Universal Model & API Definition Platform - TypeScript validation library evolving into cross-language code generation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/core/builder/context/field-context.ts
+++ b/src/core/builder/context/field-context.ts
@@ -8,6 +8,7 @@ import type {
   ChainableFieldBuilder,
   FieldBuilderContext,
   TransformFunction,
+  TypeMapping,
 } from "../plugins/plugin-types";
 import { attachComposablePlugin } from "../plugins/composable-plugin";
 
@@ -174,7 +175,7 @@ export function createOptimizedTypeBuilder<
     validators: ValidatorWithMeta<unknown>[];
     transforms: Array<TransformFunction<unknown, unknown>>;
   }
-): ChainableFieldBuilder<TObject, TPlugins, TType, any> {
+): ChainableFieldBuilder<TObject, TPlugins, TType, TypeMapping[TType]> {
   // Simplified arrays without ExecutionPlan
   const validators: ValidatorWithMeta<unknown>[] = existingState?.validators
     ? [...existingState.validators]
@@ -303,7 +304,7 @@ export function createOptimizedTypeBuilder<
     );
   };
 
-  return builder as ChainableFieldBuilder<TObject, TPlugins, TType, any>;
+  return builder as ChainableFieldBuilder<TObject, TPlugins, TType, TypeMapping[TType]>;
 }
 
 /**

--- a/src/core/builder/core/field-builder.ts
+++ b/src/core/builder/core/field-builder.ts
@@ -37,7 +37,7 @@ export function createFieldBuilderImpl<
 >(
   plugins: TPlugins,
   chainableBuilder: any,
-  fieldDefinitions: Array<FieldBuilderDefinition> = [],
+  fieldDefinitions: Array<FieldBuilderDefinition<TObject, TPlugins, any>> = [],
   isStrict: boolean = false
 ): FieldBuilder<TObject, TMap, TPlugins, TDeclaredFields> {
   // Store field definitions for deferred building with type safety
@@ -90,11 +90,12 @@ export function createFieldBuilderImpl<
       undefined;
 
     // Store field definition with type information and options preserved
-    const fieldDefinition: FieldBuilderDefinition = {
+    const fieldDefinition: FieldBuilderDefinition<TObject, TPlugins, TypeOfPath<TObject, Key>> = {
       path,
       inferredType: inferFieldType<Key>(path),
       builderFunction: definition as any,
       fieldOptions: normalizedOptions, // Store the field options
+      fieldType: {} as TypeOfPath<TObject, Key>, // Type marker for proper inference
     };
 
     // Return new instance with type safety maintained
@@ -136,11 +137,12 @@ export function createFieldBuilderImpl<
     path: Key,
     fieldRule: FieldRule<TypeOfPath<TObject, Key>>
   ): FieldBuilder<TObject, TMap, TPlugins, TDeclaredFields | Key> => {
-    const fieldDefinition: FieldBuilderDefinition = {
+    const fieldDefinition: FieldBuilderDefinition<TObject, TPlugins, TypeOfPath<TObject, Key>> = {
       path,
       inferredType: inferFieldType<Key>(path),
       builderFunction: () => fieldRule,
       fieldOptions: fieldRule.fieldOptions, // Extract field options from the field rule
+      fieldType: {} as TypeOfPath<TObject, Key>, // Type marker for proper inference
     };
 
     return createFieldBuilderImpl<TObject, TMap, TPlugins, TDeclaredFields | Key>(
@@ -198,7 +200,7 @@ export function createFieldBuilderImpl<
 
     // Process field definitions with context creation
     const processedDefinitions = _fieldDefinitions.map((def) => {
-      const context = createFieldContext<TObject, TPlugins, any>(
+      const context = createFieldContext<TObject, TPlugins, typeof def.fieldType>(
         def.path,
         plugins
       );

--- a/src/core/builder/types/types.ts
+++ b/src/core/builder/types/types.ts
@@ -328,11 +328,12 @@ import type {
 /**
  * Field definition for deferred building
  */
-export interface FieldBuilderDefinition {
+export interface FieldBuilderDefinition<TObject extends object = any, TPlugins = any, TFieldType = any> {
   path: string;
-  builderFunction: (context: FieldBuilderContext<any, any, any>) => any;
+  builderFunction: (context: FieldBuilderContext<TObject, TPlugins, TFieldType>) => any;
   inferredType?: string;
-  fieldOptions?: import("../types/field-options").FieldOptions<any>;
+  fieldOptions?: import("../types/field-options").FieldOptions<TFieldType>;
+  fieldType?: TFieldType;
 }
 
 // ========================================


### PR DESCRIPTION
  - Fix b.string/b.number/etc returning any type
  - Add type parameters to FieldBuilderDefinition
  - Pass actual field types through context creation
  - Version bump to 0.1.2-alpha